### PR TITLE
v3.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,30 +10,39 @@ source:
   sha256: edd8d3170b40c3a81b8cf910f46c6a304ae2847ec01036d02e9c0f9b85762d28
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python
+    - lxml
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - xmlrunner
     - xmlrunner.extra
 
 about:
-  home: http://github.com/xmlrunner/unittest-xml-reporting/tree/master/
-  license: BSD
+  home: https://github.com/xmlrunner/unittest-xml-reporting/tree/master/
+  license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: unittest-based test runner with Ant/JUnit like XML reporting.
+  description:
+    A unittest test runner that can save test results to XML files in xUnit format. 
+    The files can be consumed by a wide range of tools, such as build systems, 
+    IDEs and continuous integration servers.
   doc_url: https://pypi.org/project/unittest-xml-reporting/
-  dev_url: http://github.com/xmlrunner/unittest-xml-reporting
+  dev_url: https://github.com/xmlrunner/unittest-xml-reporting
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
unittest-xml-reporting v3.2.0

**Destination channel:**  defaults

### Links

- [PKG-6311](https://anaconda.atlassian.net/browse/PKG-6311) 
- [Upstream repository](https://github.com/xmlrunner/unittest-xml-reporting/tree/3.2.0)

### Explanation of changes:

- Update to our recipe standards
- Add missing dependency

### Notes
- This fork previously existed, but was never added to aggregate (or built)
- Provides `xmlrunner` needed by pytorch. 


[PKG-6311]: https://anaconda.atlassian.net/browse/PKG-6311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ